### PR TITLE
fix requirement on N. N must be >= K. N=K=2 is now allowed.

### DIFF
--- a/sss.go
+++ b/sss.go
@@ -45,7 +45,7 @@ import (
 
 var (
 	// ErrInvalidCount is returned when the count parameter is invalid.
-	ErrInvalidCount = errors.New("N must be > 2")
+	ErrInvalidCount = errors.New("N must be >= K")
 	// ErrInvalidThreshold is returned when the threshold parameter is invalid.
 	ErrInvalidThreshold = errors.New("K must be > 1")
 )
@@ -53,12 +53,12 @@ var (
 // Split the given secret into N shares of which K are required to recover the
 // secret. Returns a map of share IDs (1-255) to shares.
 func Split(n, k byte, secret []byte) (map[byte][]byte, error) {
-	if n <= 2 {
-		return nil, ErrInvalidCount
-	}
-
 	if k <= 1 {
 		return nil, ErrInvalidThreshold
+	}
+
+	if n < k {
+		return nil, ErrInvalidCount
 	}
 
 	shares := make(map[byte][]byte, n)


### PR DESCRIPTION
Is there any reason for the N > 2 requirement? I don't see any theoretical reason for not being able to do 2-out-2 secret sharing, for example. I applied the fix to allow any N >= K, and it seems to work. 
